### PR TITLE
Support for withKey / optionalWithKey for types that aren't Decodable

### DIFF
--- a/Sources/Coding/Decoding.swift
+++ b/Sources/Coding/Decoding.swift
@@ -103,6 +103,14 @@ public extension Decoding {
             return try self.decode(container.superDecoder(forKey: key))
         }
     }
+    
+    func optionalWithKey<Key: CodingKey>(_ key: Key) -> Decoding<Value?> {
+        .init { decoder in
+            let container = try decoder.container(keyedBy: Key.self)
+            guard container.contains(key) else { return nil }
+            return try self.decode(container.superDecoder(forKey: key))
+        }
+    }
 }
 
 // MARK: - Collections

--- a/Sources/Coding/Decoding.swift
+++ b/Sources/Coding/Decoding.swift
@@ -96,6 +96,15 @@ public extension Decoding where Value: Decodable {
     }
 }
 
+public extension Decoding {
+    func withKey<Key: CodingKey>(_ key: Key) -> Self {
+        .init { decoder in
+            let container = try decoder.container(keyedBy: Key.self)
+            return try self.decode(container.superDecoder(forKey: key))
+        }
+    }
+}
+
 // MARK: - Collections
 
 public extension Decoding {


### PR DESCRIPTION
Previously `withKey` and `optionalWithKey` only worked if `Value` was `Decodable`. This adds support for any `Decoding` instance by creating a keyed container and then passing _that_ into the standard `decode` implementation.

For optional we do the above, but only if the container actually has that key.